### PR TITLE
prefetchをしたときにエラーである場合はエラーを返すようにした

### DIFF
--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { ErrorComponent } from '@/components/Layout/Error/Error'
 
 export default function CustomError() {

--- a/src/components/Layout/Error/Error.tsx
+++ b/src/components/Layout/Error/Error.tsx
@@ -1,3 +1,5 @@
+import { notFound } from 'next/navigation'
+import { ResponseError } from '@/components/Layout/Error/ErrorFallback'
 
 type ErrorProps = {
   statusCode?: number
@@ -17,6 +19,20 @@ const getErrorMessage = (statusCode?: number) => {
   }
   return errorMessage
 }
+
+export const componentErrorHandler = (error:unknown) => {
+  if (error instanceof ResponseError) {
+    switch (error.getStatusCode) {
+    case 404:
+      return notFound()
+    default:
+      return <ErrorComponent statusCode={error.getStatusCode}/>
+    }
+  } else {
+    return <ErrorComponent/>
+  }
+}
+
 
 export const ErrorComponent= ({ statusCode }: ErrorProps) => {
   const errorMessage = getErrorMessage(statusCode)

--- a/src/components/Layout/Error/ErrorFallback.tsx
+++ b/src/components/Layout/Error/ErrorFallback.tsx
@@ -18,7 +18,10 @@ export class ResponseError extends Error {
 }
 
 export const ErrorFallback = ({ error }: ErrorFallbackProps) => {
-  if (instanceOf(ResponseError)) {
+  if (error instanceof ResponseError) {
     return <ErrorComponent  statusCode={error.getStatusCode} />
+  } else {
+    return <ErrorComponent />
+
   }
 }

--- a/src/features/pokemon/[pokemon]/components/Container/RootContainer.tsx
+++ b/src/features/pokemon/[pokemon]/components/Container/RootContainer.tsx
@@ -1,15 +1,20 @@
 import { dehydrate, Hydrate } from '@tanstack/react-query'
+
 import { SuspenseLoading } from '@/components/Elements/Suspense/Suspense'
-import { MyErrorBoundary } from '@/components/Layout/Error/ErrorBoundary'
+import { componentErrorHandler } from '@/components/Layout/Error/Error'
 import { PokemonContainer } from '@/features/pokemon/[pokemon]/components/Container/PokemonContainer'
 import { pokemonService } from '@/hooks/pokemon/pokemonService'
 import { getQueryClient } from '@/infrastructure/queryClient'
 
 type RootContainerProps = { params: { pokemonName: string } }
 export const RootContainer = async ({ params }: RootContainerProps)=>{
-  await pokemonService.prefetchPokemonByName(params.pokemonName)
-  const dehydratedState = dehydrate(getQueryClient())
+  try {
+    await pokemonService.prefetchPokemonByName(params.pokemonName)
+  } catch (error) {
+    componentErrorHandler(error)
+  }
 
+  const dehydratedState = dehydrate(getQueryClient())
   return (
     <>
       <Hydrate state={dehydratedState}>

--- a/src/hooks/pokemon/pokemonService.ts
+++ b/src/hooks/pokemon/pokemonService.ts
@@ -15,7 +15,7 @@ export const pokemonService = {
    * @param pokemonName
    */
   prefetchPokemonByName: async (pokemonName: string)=>{
-    await prefetch(['pokemon', pokemonName], async () => await getPokemon(pokemonName))
+    return await prefetch(['pokemon', pokemonName], async () => await getPokemon(pokemonName))
   },
 
   /**

--- a/src/hooks/tanstack/usePrefetch.ts
+++ b/src/hooks/tanstack/usePrefetch.ts
@@ -19,7 +19,7 @@ export const prefetch = async <
     'queryKey' | 'queryFn'
   >) => {
 
-  await getQueryClient().prefetchQuery({
+  return await getQueryClient().fetchQuery({
     queryKey,
     queryFn: async () => fetcher(queryKey[1]),
     ...options,


### PR DESCRIPTION
## 概要
prefetchをすると ,https://zenn.dev/hanpenman/articles/04df059c82166a , のエラーが出たのでそれを解消

## 原因
- prefetchであるとエラーが出たとしてもキャッチされないのでサーバレンダリングでエラーとなる
- suspenseでpromiseがキャッチされるのでそれがレンダリングされることになるが、おそらくpromiseが終わらないことでサーバサイドのレンダリングエラーということでエラーが起きる

## 解決
- prefetchを使うのではなく、fetchQueryを使いエラーの場合はきちんとthrowさせる